### PR TITLE
Manually patch in 'description' into QueryResultAdminVAppRecordType

### DIFF
--- a/32.0.json
+++ b/32.0.json
@@ -40381,6 +40381,10 @@
                 "description": "The name of this vApp.",
                 "type": "string"
               },
+              "description": {
+                "description": "The description of this vApp.",
+                "type": "string"
+              },
               "org": {
                 "description": "Organization reference or id",
                 "type": "string"


### PR DESCRIPTION
A VMware Cloud Director 10.1 API endpoint returns 'description' as a field
in it's response to a type=adminVApp API endpoint, whereas a 9.7 server
does not.

This manual patch to the JSON API allows code to reference the description
field. Potentially at a later date this manual patch will need to be
built in to the API generator code and applied to later versions too
as both 33.0 and 34.0 currently do not include the description field.

Ref:
[vCloud Director API v32.0 for v9.7](https://code.vmware.com/apis/553/vmware-cloud-director/doc/doc/types/QueryResultAdminVAppRecordType.html)
not showing description returned

[QueryResultAdminVAppRecordType v1.5 documentation](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/06a3b3da-4c6d-4984-b795-5d64081a4b10/8e47d46b-cfa7-4c06-8b81-4f5548da3102/doc/doc//types/QueryResultAdminVAppRecordType.html)
showing description returned